### PR TITLE
4 srs add reset features and hv onoff sequence

### DIFF
--- a/ioc/SRS300App/Db/devSRS_PS3xx.template
+++ b/ioc/SRS300App/Db/devSRS_PS3xx.template
@@ -217,9 +217,16 @@ record(bo, "$(P)$(R)HVenable")
     field(ZNAM, "Turn Off")
     field(ONAM, "Turn On")
     field(PINI, "YES")
-    field(FLNK, "$(P)$(R)getSTB")
+    field(FLNK, "$(P)$(R)HVenableSeq")
 }
 
+record(seq, "$(P)$(R)HVenableSeq")
+{
+    field(DESC, "Sequence to dis/enable HV")
+    field(DO1, "$(VMIN)")
+    field(LNK1, "$(P)$(R)HVset PP")
+    field(LNK2, "$(P)$(R)getSTB.PROC PP")
+}
 #____________________________________________
 #_________Start ramping process______________
 

--- a/ioc/SRS300App/Db/devSRS_PS3xx.template
+++ b/ioc/SRS300App/Db/devSRS_PS3xx.template
@@ -427,3 +427,26 @@ record(bi,"$(P)$(R)E_smallStep"){
     field(ZNAM, "Safe")
     field(ONAM, "Step below minimum")
 }
+
+#______________________________________________
+#_______________Reset button__________________
+
+record(seq, "$(P)$(R)hardReset"){
+    field(DESC, "Hard reset sequence")
+    field(DO1, "0")
+    field(LNK1, "$(P)$(R)HVenable PP")
+    field(DO2, "1")
+    field(LNK2, "$(P)$(R)TripClear PP")
+    field(LNK3, "$(P)$(R)ResetDevice.PROC PP")
+    field(DO4, "1")
+    field(LNK4, "$(P)$(R)HVenable PP")
+}
+
+record(bo, "$(P)$(R)ResetDevice")
+{
+    field(DESC, "Reset device")
+    field(DTYP, "stream")
+    field(OUT,  "@ps300.proto cmd(RST) $(PORT) $(A)")
+    field(ZNAM, "Reset Device")
+    field(ONAM, "Reset Device")
+}

--- a/ui/bench_HVPS.bob
+++ b/ui/bench_HVPS.bob
@@ -566,7 +566,7 @@ else:
         <value>0</value>
       </action>
     </actions>
-    <pv_name>$(P)$(R)TripClear</pv_name>
+    <pv_name>$(P)$(R)hardReset</pv_name>
     <text>Reset</text>
     <x>17</x>
     <y>408</y>
@@ -658,8 +658,8 @@ else:
     <name>LED (Multi State)</name>
     <x>350</x>
     <y>450</y>
-    <width>0</width>
-    <height>0</height>
+    <width>1</width>
+    <height>1</height>
     <states>
       <state>
         <value>0</value>


### PR DESCRIPTION
Added sequence that sets voltage to 0 once turned on or off to prevent voltage jumping up to it's previous value once turned back on.
Added a reset button which clears any trips then sends the reset command to the device.
Added a 'soft reset' button which clears any trips.